### PR TITLE
Additional configuration flag to enable cluster mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,20 @@ module "fake_redis" {
 | auth\_required | Should redis AUTH be enabled for this cluster | string | `false` | no |
 | auth\_token | The password for redis AUTH | string | `` | no |
 | auto\_minor\_version\_upgrade | Should the cluster autmoatically be updated to the latest minor vesrion | string | `false` | no |
+| automatic_failover_enabled | Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. Must be enabled for Redis (cluster mode enabled) replication groups. | string | `false` | no |
 | cidr\_blocks | cidr blocks from which this cluster should accept connections | list | `<list>` | no |
 | engine\_version | The engine version for this cluster | string | `4.0.10` | no |
 | environment | The environment the redis cluster is running in i.e. dev, prod etc | string | - | yes |
+| kms_key_id | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if at_rest_encryption_enabled is true | string | - | no |
 | name | A descriptive name for the redis cluster | string | - | yes |
 | node\_type | The type of nodes to use for this cluster | string | - | yes |
+| notification\_topic\_arn | The ARN of an SNS topic to send Elasticache notifications to | string | - | no |
+| num\_node\_groups | For cluster mode: the number of node groups (shards) for this Redis replication group (required if using cluster mode) | string | - | no |
 | number\_of\_nodes | The number of nodes in this cluster | string | `1` | no |
-| paramter\_group\_name | The parameter group name for this cluster | string | `default.redis4.0` | no |
+| parameter\_group\_name | The parameter group name for this cluster | string | `default.redis4.0` | no |
+| replicas\_per\_node\_group | For cluster mode: the number of replica nodes in each node group (required if using cluster mode)| string | - | no |
+| snapshot\_retention\_limit | Redis only: the retention period of snapshots kept in days | string | - | no |
+| snapshot\_window | The daily time range which ElastiCache will begin taking daily snapshots | string | - | no |
 | subnet\_ids | The list of subnet IDs associated to a vpc | list | `<list>` | no |
 | tags | A map of tags to add to all resources | map | `<map>` | no |
 | transit\_encryption\_enabled | Should transit encryption be enabled for this cluster | string | `false` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -8,7 +8,7 @@ variable "environment" {
 
 variable "number_of_nodes" {
   description = "The number of nodes in this cluster"
-  default     = 1
+  default     = ""
 }
 
 variable "node_type" {
@@ -59,7 +59,7 @@ variable "engine_version" {
   default     = "4.0.10"
 }
 
-variable "paramter_group_name" {
+variable "parameter_group_name" {
   description = "The parameter group name for this cluster"
   default     = "default.redis4.0"
 }
@@ -69,3 +69,37 @@ variable "auto_minor_version_upgrade" {
   default     = false
 }
 
+variable "replicas_per_node_group" {
+  description = "Set for cluster mode: the number of replica nodes in each node group (required if using cluster mode)"
+  default     = ""
+}
+
+variable "num_node_groups" {
+  description = "Set for cluster mode: the number of node groups (shards) for this Redis replication group (required if using cluster mode)"
+  default     = ""
+}
+
+variable "notification_topic_arn" {
+  description = "The ARN of an SNS topic to send Elasticache notifications to"
+  default     = ""
+}
+
+variable "snapshot_window" {
+  description = "The daily time range which ElastiCache will begin taking daily snapshots"
+  default     = ""
+}
+
+variable "snapshot_retention_limit" {
+  description = "Redis only: the retention period of snapshots kept in days"
+  default     = ""
+}
+
+variable "automatic_failover_enabled" {
+  description = "Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. Must be enabled for Redis (cluster mode enabled) replication groups."
+  default     = "false"
+}
+
+variable "kms_key_id" {
+  description = "The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if at_rest_encryption_enabled is true"
+  default     = ""
+}


### PR DESCRIPTION
- Enabled configuration for clustered Redis
- Extra flags for:
  - Configurable automatic failover (needed for redis cluster)
  - Subscribing SNS notification topic
  - Number of node groups (needed for cluster mode)
  - Fixed parameter group flag typo
  - Replicas per node group (needed for cluster mode)
  - Snapshot retention period
  - Snapshot window
  - KMS key ID