### PR TITLE
Revert change to security group description to prevent replacement

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "aws_elasticache_replication_group" "elasticache_redis_cluster" {
 
 resource "aws_security_group" "elasticache_redis_cluster" {
   name        = "${var.name}-security-group"
-  description = "The security group used to manage access to the redis cluster"
+  description = "The security group used to manage access to the test redis cluster"
   vpc_id      = var.vpc_id
 
   tags = merge(


### PR DESCRIPTION
This allows the previous change to the egress rules (#10) to be done on an existing Redis instance without having to replace the security group (which can lead to a dependancy error when Terraform tries to delete the old security group)