### PR TITLE
ACPENG-3033 widen AWS provider constraint to >= 3.0, < 5.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 3.0, < 5.0"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
See https://support.acp.homeoffice.gov.uk/browse/ACP-25345 